### PR TITLE
fix: Removed the `actual_collection_date` field from the shipment response 🐧 

### DIFF
--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -123,10 +123,6 @@ defmodule DocsWeb.Schemas.Response.Shipment do
       schedule: %Schema{
         type: :object,
         properties: %{
-          actual_collection_date: %Schema{
-            type: :string,
-            format: :date
-          },
           delivery_end: %Schema{
             type: :string,
             format: :date


### PR DESCRIPTION
As mentioned [here](https://linear.app/arta/issue/SHP-118/add-documentation-for-the-actual-collection-date-field-on-the-api#comment-a451bac9), we decided to remove the actual_collection_date field from the customer context shipment endpoints. This PR removes it.