### PR TITLE
fix: adds missing tag fields on shipment, request, and hosted session endpoints

### DIFF
--- a/lib/docs_web/schemas/request_body/hosted_session_create.ex
+++ b/lib/docs_web/schemas/request_body/hosted_session_create.ex
@@ -80,6 +80,15 @@ defmodule DocsWeb.Schemas.RequestBody.HostedSessionCreate do
                 description:
                   "The URL the user will be redirected to after a Arta Booking session is completed",
                 example: "http://example.com/success"
+              },
+              tags: %Schema{
+                type: :array,
+                description: "A list of tags to associate with this hosted session",
+                items: %Schema{
+                  type: :string,
+                  description: "The name of an active tag belonging to your organization.",
+                  example: "spring-jewelry-sale"
+                }
               }
             }
           }

--- a/lib/docs_web/schemas/request_body/request_create.ex
+++ b/lib/docs_web/schemas/request_body/request_create.ex
@@ -381,6 +381,15 @@ defmodule DocsWeb.Schemas.RequestBody.RequestCreate do
             description:
               "This field can be used to pass through any notes to Arta that a customer might want to provide about the request",
             example: "New customer"
+          },
+          tags: %Schema{
+            type: :array,
+            description: "A list of tags to associate with this request",
+            items: %Schema{
+              type: :string,
+              description: "The name of an active tag belonging to your organization.",
+              example: "ny-warehouse"
+            }
           }
         }
       }

--- a/lib/docs_web/schemas/request_body/shipment_create.ex
+++ b/lib/docs_web/schemas/request_body/shipment_create.ex
@@ -41,6 +41,16 @@ defmodule DocsWeb.Schemas.RequestBody.ShipmentCreate do
                   "This field can be used to pass through any notes to Arta that a customer might want to provide about the request",
                 maxLength: 255,
                 example: "New customer"
+              },
+              tags: %Schema{
+                type: :array,
+                description:
+                  "A list of tags to associate with this shipment. Tags present on the request will also be set on the shipment",
+                items: %Schema{
+                  type: :string,
+                  description: "The name of an active tag belonging to your organization.",
+                  example: "vip"
+                }
               }
             },
             required: ["quote_id"]
@@ -119,6 +129,15 @@ defmodule DocsWeb.Schemas.RequestBody.ShipmentCreate do
                 items: Payload.Package.call(:track),
                 description:
                   "The shipments packages are formatted as a list, however, Track shipments only support a single package. You can provide details about the package being shipped, including the object details within the package"
+              },
+              tags: %Schema{
+                type: :array,
+                description: "A list of tags to associate with this shipment",
+                items: %Schema{
+                  type: :string,
+                  description: "The name of an active tag belonging to your organization.",
+                  example: "vip"
+                }
               }
             },
             required: ["tracking"]

--- a/lib/docs_web/schemas/response/hosted_session.ex
+++ b/lib/docs_web/schemas/response/hosted_session.ex
@@ -44,6 +44,11 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
         maxLength: 255,
         nullable: true
       },
+      objects: %Schema{
+        type: "array",
+        description: "A list of objects to be shipped",
+        items: Response.Object
+      },
       origin: Response.Location,
       payment_process: %Schema{
         type: :string,
@@ -52,6 +57,14 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
         example: "checkout",
         enum: ["checkout", "invoicing"],
         readOnly: true
+      },
+      preferred_quote_types: %Schema{
+        type: :array,
+        description:
+          "An optional field presenting the list of quote types the caller instructed Arta to return as part of the hosted session",
+        items: %Schema{
+          type: :string
+        }
       },
       private_token: %Schema{
         type: :string,
@@ -85,6 +98,11 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
         description:
           "The URL the user will be redirected to after an Arta Booking session is completed"
       },
+      tags: %Schema{
+        type: :array,
+        description: "A list of tags associated with this hosted session",
+        items: DocsWeb.Schemas.Response.Tag
+      },
       updated_at: %Schema{
         type: :string
       },
@@ -92,19 +110,6 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
         type: :string,
         description: "The Arta Booking web URL for this Hosted Session",
         nullable: true
-      },
-      preferred_quote_types: %Schema{
-        type: :array,
-        description:
-          "An optional field presenting the list of quote types the caller instructed Arta to return as part of the hosted session",
-        items: %Schema{
-          type: :string
-        }
-      },
-      objects: %Schema{
-        type: "array",
-        description: "A list of objects to be shipped",
-        items: Response.Object
       }
     },
     example: %{
@@ -169,6 +174,7 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
       "shortcode" => "DEMO-B49SVZ",
       "status" => "new",
       "success_url" => "http://example.com/success",
+      "tags" => [],
       "updated_at" => "2021-01-21T17:22:10.129653",
       "url" => "https://book.arta.io/b/42/6f76b6e1-ce25-43a9-b4ea-2ceaac24ec7e"
     }

--- a/lib/docs_web/schemas/response/request.ex
+++ b/lib/docs_web/schemas/response/request.ex
@@ -392,6 +392,11 @@ defmodule DocsWeb.Schemas.Response.Request do
               type: "string",
               example: "published"
             },
+            tags: %Schema{
+              type: :array,
+              description: "A list of tags associated with this request",
+              items: DocsWeb.Schemas.Response.Tag
+            },
             total: MonetaryAmount.schema(),
             total_currency: Currency.schema()
           }
@@ -876,6 +881,7 @@ defmodule DocsWeb.Schemas.Response.Request do
       "shipping_notes" => nil,
       "shortcode" => "DEMO-R29NAW",
       "status" => "quoted",
+      "tags" => [],
       "updated_at" => "2021-01-21T17:22:10.129653"
     }
   })

--- a/lib/docs_web/schemas/response/request_list_item.ex
+++ b/lib/docs_web/schemas/response/request_list_item.ex
@@ -196,6 +196,7 @@ defmodule DocsWeb.Schemas.Response.RequestListItem do
       "quote_types" => ["parcel", "select", "premium"],
       "shortcode" => "DEMO-R29NAW",
       "status" => "closed",
+      "tags" => [],
       "updated_at" => "2021-01-21T21:00:58.484566"
     }
   })

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -4,7 +4,8 @@ defmodule DocsWeb.Schemas.Response.Shipment do
   alias DocsWeb.Schemas.Response.{
     Package,
     Service,
-    ShipmentException
+    ShipmentException,
+    Tag
   }
 
   alias DocsWeb.Schemas.{Currency, MonetaryAmount, Response}
@@ -179,9 +180,7 @@ defmodule DocsWeb.Schemas.Response.Shipment do
       tags: %Schema{
         type: :array,
         description: "A list of tags associated with the shipment",
-        items: %Schema{
-          type: :string
-        }
+        items: Tag
       },
       total: MonetaryAmount,
       total_currency: Currency,
@@ -389,6 +388,7 @@ defmodule DocsWeb.Schemas.Response.Shipment do
       "status" => "pending",
       "total" => "4",
       "total_currency" => "USD",
+      "tags" => [],
       "tracking" => [],
       "updated_at" => "2021-01-21T21:00:58.579870",
       "url" =>

--- a/lib/docs_web/schemas/response/shipment_list.ex
+++ b/lib/docs_web/schemas/response/shipment_list.ex
@@ -114,6 +114,7 @@ defmodule DocsWeb.Schemas.Response.ShipmentList do
       "quote_type" => "parcel",
       "shortcode" => "DEMO-572652",
       "status" => "pending",
+      "tags" => [],
       "total" => "405.53",
       "total_currency" => "USD",
       "updated_at" => "2021-01-21T21:00:58.403150"


### PR DESCRIPTION
I missed these in https://github.com/artaio/api-reference/pull/23