### PR TITLE
fix: marks location access restrictions as deprecated

### DIFF
--- a/lib/docs_web/api_spec.ex
+++ b/lib/docs_web/api_spec.ex
@@ -777,6 +777,7 @@ defmodule DocsWeb.ApiSpec do
         "/metadata/location_access_restrictions" => %PathItem{
           get: %Operation{
             summary: "Location Access Restrictions",
+            deprecated: true,
             description: "The list of location access restriction types supported by Arta's API.",
             tags: [
               "metadata"

--- a/lib/docs_web/schemas/request_body/request_create.ex
+++ b/lib/docs_web/schemas/request_body/request_create.ex
@@ -42,6 +42,7 @@ defmodule DocsWeb.Schemas.RequestBody.RequestCreate do
             properties: %{
               access_restrictions: %Schema{
                 type: :array,
+                deprecated: true,
                 description:
                   "A list of access restricition IDs describing physical properties for the location. Options are defined in the Location Access Restrictions metadata endpoint",
                 items: %Schema{
@@ -279,6 +280,7 @@ defmodule DocsWeb.Schemas.RequestBody.RequestCreate do
             properties: %{
               access_restrictions: %Schema{
                 type: :array,
+                deprecated: true,
                 description:
                   "A list of access restricition ids describing physical properties of the location. Options are defined in the Location Access Restrictions metadata endpoint ",
                 items: %Schema{
@@ -394,6 +396,6 @@ defmodule DocsWeb.Schemas.RequestBody.RequestCreate do
         }
       }
     },
-    required: ["request"],
+    required: ["request"]
   })
 end


### PR DESCRIPTION
We had this noted in a few spots but not everywhere. This simply makes it more consistent across endpoints.