### PR TITLE
feat: Introduced the object components to the input/output views

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To run this project, you will need to install the following dependencies on your
 
 - [Elixir](https://elixir-lang.org/install.html)
 - [Scalar CLI](https://github.com/scalar/scalar?tab=readme-ov-file#cli)
+- [jq](https://jqlang.org/)
 
 ## Generate the API specification
 

--- a/lib/docs_web/api_spec.ex
+++ b/lib/docs_web/api_spec.ex
@@ -863,6 +863,26 @@ defmodule DocsWeb.ApiSpec do
             }
           }
         },
+        "/metadata/object_components" => %PathItem{
+          get: %Operation{
+            summary: "Object Components",
+            description: "The list of object component types supported by Arta's API.",
+            tags: [
+              "metadata"
+            ],
+            operationId: "metadata/objectComponents",
+            parameters: [Authorization.parameter()],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "A collection of object component types",
+                  "application/json",
+                  Response.Metadata.ObjectComponent,
+                  headers: default_headers()
+                )
+            }
+          }
+        },
         "/metadata/object_materials" => %PathItem{
           get: %Operation{
             summary: "Object Materials",

--- a/lib/docs_web/schemas/fields.ex
+++ b/lib/docs_web/schemas/fields.ex
@@ -7,7 +7,8 @@ defmodule DocsWeb.Schemas.Fields do
     %{
       components: %Schema{
         type: "array",
-        description: "A list of components in the object",
+        description:
+          "A list of components in the object. Should be used only with a `prepacked_box` object subtype",
         items: %Schema{
           type: :object,
           properties: object_component_fields()

--- a/lib/docs_web/schemas/fields.ex
+++ b/lib/docs_web/schemas/fields.ex
@@ -196,6 +196,37 @@ defmodule DocsWeb.Schemas.Fields do
 
   def object_component_fields() do
     %{
+      customs: %Schema{
+        type: "object",
+        properties: %{
+          country_of_origin: %Schema{
+            description:
+              "The ISO 3166-1 alpha-2 country code where the object was made or manufactured",
+            type: "string",
+            maxLength: 2,
+            minLength: 2,
+            example: "US"
+          },
+          hs_code: %Schema{
+            description:
+              "The Harmonized System code for the object. This is a 6-10 digit code used to classify traded products",
+            type: "string",
+            example: "123456"
+          },
+          medium: %Schema{
+            description:
+              "The medium of the object. This is a description of the material or materials used to create the object",
+            type: "string",
+            example: "oil on canvas"
+          },
+          temporary_admission: %Schema{
+            description:
+              "Select true if the goods are currently in the country under a temporary admission declaration",
+            type: "boolean",
+            example: true
+          }
+        }
+      },
       details: %Schema{
         type: "object",
         properties: %{

--- a/lib/docs_web/schemas/fields.ex
+++ b/lib/docs_web/schemas/fields.ex
@@ -5,12 +5,13 @@ defmodule DocsWeb.Schemas.Fields do
 
   def object_fields() do
     %{
-      internal_reference: %Schema{
-        description:
-          "This field can be used to pass through any data that you may want returned unaltered for your own later usage",
-        maxLength: 255,
-        type: "string",
-        example: "Accession ID: 823"
+      components: %Schema{
+        type: "array",
+        description: "A list of components in the object",
+        items: %Schema{
+          type: :object,
+          properties: object_component_fields()
+        }
       },
       current_packing: %Schema{
         type: "array",
@@ -59,6 +60,28 @@ defmodule DocsWeb.Schemas.Fields do
       details: %Schema{
         type: "object",
         properties: %{
+          creation_date: %Schema{
+            description: "Details about the timing in which an object was created",
+            type: "string",
+            example: "1980"
+          },
+          creator: %Schema{
+            description: "The creator of the object",
+            type: "string",
+            example: "Bob Smithson"
+          },
+          is_fragile: %Schema{
+            type: "boolean",
+            description:
+              "Set this flag to true is the item is fragile. This may effect packing and handling costs",
+            default: false
+          },
+          is_cites: %Schema{
+            type: "boolean",
+            description:
+              "Set to true if the object is governed by the Convention on International Trade in Endangered Species of Wild Fauna and Flora",
+            default: false
+          },
           materials: %Schema{
             type: "array",
             deprecated: true,
@@ -68,6 +91,112 @@ defmodule DocsWeb.Schemas.Fields do
               example: "canvas"
             }
           },
+          notes: %Schema{
+            type: "string",
+            description: "Any notes about the item",
+            example: "Artist signature in the lower left corner"
+          },
+          title: %Schema{
+            type: "string",
+            description: "The object title",
+            example: "Black Rectangle"
+          }
+        }
+      },
+      height: %Schema{
+        description: "The height of the object",
+        type: "string",
+        example: "32"
+      },
+      images: %Schema{
+        type: "array",
+        description: "A list image urls of the object",
+        items: %Schema{
+          type: "string",
+          format: "uri",
+          example: "http://example.com/image.jpg"
+        }
+      },
+      internal_reference: %Schema{
+        description:
+          "This field can be used to pass through any data that you may want returned unaltered for your own later usage",
+        maxLength: 255,
+        type: "string",
+        example: "Accession ID: 823"
+      },
+      public_reference: %Schema{
+        description:
+          "A client defined name for the object. The value provided for public_reference may be presented in notification emails and on shipment detail pages",
+        type: "string",
+        maxLength: 255,
+        example: "Round Smithson work"
+      },
+      subtype: %Schema{
+        description:
+          "The object subtype ID. Options are defined in the Object types metadata endpoint",
+        type: "string",
+        pattern: "^[0-9a-z_]{1,56}$",
+        example: "painting_unframed"
+      },
+      unit_of_measurement: %Schema{
+        type: "string",
+        enum: [
+          "in",
+          "cm"
+        ],
+        example: "in"
+      },
+      value: MonetaryAmount,
+      value_currency: Currency,
+      weight: %Schema{
+        description: "The weight of the object",
+        type: "string",
+        example: "3.0"
+      },
+      weight_unit: %Schema{
+        description: "The unit of the object",
+        type: "string",
+        enum: [
+          "lb",
+          "kg"
+        ],
+        example: "lb"
+      },
+      width: %Schema{
+        description: "The width of the object",
+        type: "string",
+        example: "15"
+      }
+    }
+  end
+
+  def object_fields_with_response_fields() do
+    object_fields()
+    |> Map.put(:id, %Schema{
+      type: :integer,
+      format: :int64
+    })
+    |> Map.put(:type, %Schema{
+      type: "string",
+      description: "The object type id",
+      pattern: "^[0-9a-z_]{1,56}$"
+    })
+    |> Map.update!(:components, fn component_schema ->
+      %{
+        component_schema
+        | items: %Schema{
+            type: :object,
+            properties: object_component_fields_with_id()
+          }
+      }
+    end)
+  end
+
+  def object_component_fields() do
+    %{
+      details: %Schema{
+        type: "object",
+        properties: %{
           creation_date: %Schema{
             description: "Details about the timing in which an object was created",
             type: "string",
@@ -87,34 +216,15 @@ defmodule DocsWeb.Schemas.Fields do
             type: "string",
             description: "The object title",
             example: "Black Rectangle"
-          },
-          is_fragile: %Schema{
-            type: "boolean",
-            description:
-              "Set this flag to true is the item is fragile. This may effect packing and handling costs",
-            default: false
-          },
-          is_cites: %Schema{
-            type: "boolean",
-            description:
-              "Set to true if the object is governed by the Convention on International Trade in Endangered Species of Wild Fauna and Flora",
-            default: false
           }
         }
       },
-      height: %Schema{
-        description: "The height of the object",
+      internal_reference: %Schema{
+        description:
+          "This field can be used to pass through any data that you may want returned unaltered for your own later usage",
+        maxLength: 255,
         type: "string",
-        example: "32"
-      },
-      images: %Schema{
-        type: "array",
-        description: "A list image urls of the object",
-        items: %Schema{
-          type: "string",
-          format: "uri",
-          example: "http://example.com/image.jpg"
-        }
+        example: "Accession ID: 823"
       },
       public_reference: %Schema{
         description:
@@ -123,50 +233,22 @@ defmodule DocsWeb.Schemas.Fields do
         maxLength: 255,
         example: "Round Smithson work"
       },
-      subtype: %Schema{
+      type: %Schema{
         description:
-          "The object subtype ID. Options are defined in the Object types metadata endpoint",
+          "The object component type ID. Options are defined in the Object Component types metadata endpoint",
         type: "string",
         pattern: "^[0-9a-z_]{1,56}$",
-        example: "painting_unframed"
-      },
-      width: %Schema{
-        description: "The width of the object",
-        type: "string",
-        example: "15"
-      },
-      unit_of_measurement: %Schema{
-        type: "string",
-        enum: [
-          "in",
-          "cm"
-        ],
-        example: "in"
-      },
-      weight: %Schema{
-        description: "The weight of the object",
-        type: "string",
-        example: "3.0"
-      },
-      weight_unit: %Schema{
-        description: "The unit of the object",
-        type: "string",
-        enum: [
-          "lb",
-          "kg"
-        ],
-        example: "lb"
-      },
-      value_currency: Currency,
-      value: MonetaryAmount
+        example: "painting_framed"
+      }
     }
   end
 
-  def object_fields_with_id() do
-    object_fields()
+  def object_component_fields_with_id() do
+    object_component_fields()
     |> Map.put(:id, %Schema{
-      type: :integer,
-      format: :int64
+      type: :string,
+      description: "The id of the component in UUID format",
+      format: :uuid
     })
   end
 

--- a/lib/docs_web/schemas/fields.ex
+++ b/lib/docs_web/schemas/fields.ex
@@ -8,10 +8,11 @@ defmodule DocsWeb.Schemas.Fields do
       components: %Schema{
         type: "array",
         description:
-          "A list of components in the object. Should be used only with a `prepacked_box` object subtype",
+          "A list of components in the object. Should be used only with a `prepacked_box` object subtype.\n\nWhen components are present, the object value must equal the sum of component values.",
         items: %Schema{
           type: :object,
-          properties: object_component_fields()
+          properties: object_component_fields(),
+          required: ["type", "value"]
         }
       },
       current_packing: %Schema{

--- a/lib/docs_web/schemas/fields.ex
+++ b/lib/docs_web/schemas/fields.ex
@@ -240,7 +240,9 @@ defmodule DocsWeb.Schemas.Fields do
         type: "string",
         pattern: "^[0-9a-z_]{1,56}$",
         example: "painting_framed"
-      }
+      },
+      value: MonetaryAmount,
+      value_currency: Currency
     }
   end
 

--- a/lib/docs_web/schemas/response/hosted_session.ex
+++ b/lib/docs_web/schemas/response/hosted_session.ex
@@ -134,6 +134,47 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
       "internal_reference" => nil,
       "objects" => [
         %{
+          "components" => [
+            %{
+              "details" => %{
+                "creation_date" => "1980",
+                "creator" => "Bob Smithson",
+                "title" => "Black Rectangle",
+                "notes" => "Artist signature in the lower left corner"
+              },
+              "id" => "1f26b6e1-ce25-43a9-b4ea-2ceaac24ec3a",
+              "internal_reference" => "Accession ID: 823",
+              "public_reference" => "Round Smithson work",
+              "type" => "painting_framed"
+            }
+          ],
+          "current_packing" => ["cardboard_box"],
+          "depth" => "2",
+          "details" => %{
+            "creation_date" => nil,
+            "creator" => nil,
+            "is_cites" => false,
+            "is_fragile" => false,
+            "materials" => [],
+            "notes" => nil,
+            "title" => nil
+          },
+          "height" => "10.5",
+          "id" => 12346,
+          "images" => [],
+          "internal_reference" => nil,
+          "public_reference" => nil,
+          "subtype" => "prepacked_box",
+          "type" => "client_package",
+          "unit_of_measurement" => "in",
+          "value" => "15000",
+          "value_currency" => "USD",
+          "weight" => "3.5",
+          "weight_unit" => "lb",
+          "width" => "10"
+        },
+        %{
+          "components" => [],
           "current_packing" => [],
           "customs" => %{
             "country_of_origin" => "US",

--- a/lib/docs_web/schemas/response/hosted_session.ex
+++ b/lib/docs_web/schemas/response/hosted_session.ex
@@ -145,7 +145,9 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
               "id" => "1f26b6e1-ce25-43a9-b4ea-2ceaac24ec3a",
               "internal_reference" => "Accession ID: 823",
               "public_reference" => "Round Smithson work",
-              "type" => "painting_framed"
+              "type" => "painting_framed",
+              "value" => "15000",
+              "value_currency" => "USD"
             }
           ],
           "current_packing" => ["cardboard_box"],

--- a/lib/docs_web/schemas/response/hosted_session.ex
+++ b/lib/docs_web/schemas/response/hosted_session.ex
@@ -136,6 +136,12 @@ defmodule DocsWeb.Schemas.Response.HostedSession do
         %{
           "components" => [
             %{
+              "customs" => %{
+                "country_of_origin" => "US",
+                "hs_code" => "123456",
+                "medium" => "oil on canvas",
+                "temporary_admission" => true
+              },
               "details" => %{
                 "creation_date" => "1980",
                 "creator" => "Bob Smithson",

--- a/lib/docs_web/schemas/response/metadata/object_component.ex
+++ b/lib/docs_web/schemas/response/metadata/object_component.ex
@@ -1,0 +1,30 @@
+defmodule DocsWeb.Schemas.Response.Metadata.ObjectComponent do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "MetadataObjectComponent",
+    type: :array,
+    items: %Schema{
+      type: :object,
+      properties: %{
+        description: %Schema{
+          type: :string,
+          description: "A long form description",
+          example: "A painting that is framed behind a glass face."
+        },
+        id: %Schema{
+          type: :string,
+          description: "The ID representing the resource",
+          example: "painting_framed_glass"
+        },
+        name: %Schema{
+          type: :string,
+          description: "A brief title for the resource",
+          example: "Painting (framed with glass)"
+        }
+      }
+    }
+  })
+end

--- a/lib/docs_web/schemas/response/object.ex
+++ b/lib/docs_web/schemas/response/object.ex
@@ -5,6 +5,6 @@ defmodule DocsWeb.Schemas.Response.Object do
 
   OpenApiSpex.schema(%{
     type: :object,
-    properties: Fields.object_fields_with_id()
+    properties: Fields.object_fields_with_response_fields()
   })
 end

--- a/lib/docs_web/schemas/response/request.ex
+++ b/lib/docs_web/schemas/response/request.ex
@@ -1,6 +1,7 @@
 defmodule DocsWeb.Schemas.Response.Request do
   alias DocsWeb.Schemas.{Currency, MonetaryAmount}
   alias DocsWeb.Schemas.Response.{Location, Object}
+
   alias OpenApiSpex.Schema
 
   require OpenApiSpex
@@ -382,6 +383,12 @@ defmodule DocsWeb.Schemas.Response.Request do
         %{
           "components" => [
             %{
+              "customs" => %{
+                "country_of_origin" => "US",
+                "hs_code" => "123456",
+                "medium" => "oil on canvas",
+                "temporary_admission" => true
+              },
               "details" => %{
                 "creation_date" => "1980",
                 "creator" => "Bob Smithson",

--- a/lib/docs_web/schemas/response/request.ex
+++ b/lib/docs_web/schemas/response/request.ex
@@ -380,6 +380,47 @@ defmodule DocsWeb.Schemas.Response.Request do
       "object_count" => 1,
       "objects" => [
         %{
+          "components" => [
+            %{
+              "details" => %{
+                "creation_date" => "1980",
+                "creator" => "Bob Smithson",
+                "title" => "Black Rectangle",
+                "notes" => "Artist signature in the lower left corner"
+              },
+              "id" => "1f26b6e1-ce25-43a9-b4ea-2ceaac24ec3a",
+              "internal_reference" => "Accession ID: 823",
+              "public_reference" => "Round Smithson work",
+              "type" => "painting_framed"
+            }
+          ],
+          "current_packing" => ["cardboard_box"],
+          "depth" => "2",
+          "details" => %{
+            "creation_date" => nil,
+            "creator" => nil,
+            "is_cites" => false,
+            "is_fragile" => false,
+            "materials" => [],
+            "notes" => nil,
+            "title" => nil
+          },
+          "height" => "10.5",
+          "id" => 1644,
+          "images" => [],
+          "internal_reference" => nil,
+          "public_reference" => nil,
+          "subtype" => "prepacked_box",
+          "type" => "client_package",
+          "unit_of_measurement" => "in",
+          "value" => "15000",
+          "value_currency" => "USD",
+          "weight" => "3.5",
+          "weight_unit" => "lb",
+          "width" => "10"
+        },
+        %{
+          "components" => [],
           "current_packing" => [],
           "customs" => %{
             "country_of_origin" => "US",
@@ -394,6 +435,7 @@ defmodule DocsWeb.Schemas.Response.Request do
             "is_cites" => false,
             "is_fragile" => false,
             "materials" => [],
+            "notes" => "Artist signature in the lower left corner",
             "title" => "All That Jazz"
           },
           "height" => "10.5",

--- a/lib/docs_web/schemas/response/request.ex
+++ b/lib/docs_web/schemas/response/request.ex
@@ -391,7 +391,9 @@ defmodule DocsWeb.Schemas.Response.Request do
               "id" => "1f26b6e1-ce25-43a9-b4ea-2ceaac24ec3a",
               "internal_reference" => "Accession ID: 823",
               "public_reference" => "Round Smithson work",
-              "type" => "painting_framed"
+              "type" => "painting_framed",
+              "value" => "15000",
+              "value_currency" => "USD"
             }
           ],
           "current_packing" => ["cardboard_box"],

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -377,6 +377,47 @@ defmodule DocsWeb.Schemas.Response.Shipment do
           "is_sufficiently_packed" => false,
           "objects" => [
             %{
+              "components" => [
+                %{
+                  "details" => %{
+                    "creation_date" => "1980",
+                    "creator" => "Bob Smithson",
+                    "title" => "Black Rectangle",
+                    "notes" => "Artist signature in the lower left corner"
+                  },
+                  "id" => "1f26b6e1-ce25-43a9-b4ea-2ceaac24ec3a",
+                  "internal_reference" => "Accession ID: 823",
+                  "public_reference" => "Round Smithson work",
+                  "type" => "painting_framed"
+                }
+              ],
+              "current_packing" => ["cardboard_box"],
+              "depth" => "2",
+              "details" => %{
+                "creation_date" => nil,
+                "creator" => nil,
+                "is_cites" => false,
+                "is_fragile" => false,
+                "materials" => [],
+                "notes" => nil,
+                "title" => nil
+              },
+              "height" => "10.5",
+              "id" => 621,
+              "images" => [],
+              "internal_reference" => nil,
+              "public_reference" => nil,
+              "subtype" => "prepacked_box",
+              "type" => "client_package",
+              "unit_of_measurement" => "in",
+              "value" => "15000",
+              "value_currency" => "USD",
+              "weight" => "3.5",
+              "weight_unit" => "lb",
+              "width" => "10"
+            },
+            %{
+              "components" => [],
               "current_packing" => [],
               "customs" => %{
                 "country_of_origin" => "US",
@@ -391,6 +432,7 @@ defmodule DocsWeb.Schemas.Response.Shipment do
                 "is_cites" => false,
                 "is_fragile" => false,
                 "materials" => [],
+                "notes" => "Artist signature in the lower left corner",
                 "title" => "All That Jazz"
               },
               "height" => "10.5",

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -388,7 +388,9 @@ defmodule DocsWeb.Schemas.Response.Shipment do
                   "id" => "1f26b6e1-ce25-43a9-b4ea-2ceaac24ec3a",
                   "internal_reference" => "Accession ID: 823",
                   "public_reference" => "Round Smithson work",
-                  "type" => "painting_framed"
+                  "type" => "painting_framed",
+                  "value" => "15000",
+                  "value_currency" => "USD"
                 }
               ],
               "current_packing" => ["cardboard_box"],

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -226,49 +226,59 @@ defmodule DocsWeb.Schemas.Response.Shipment do
               properties: %{
                 png_4_x_6: %Schema{
                   type: :string,
-                  description: "PNG 4x6 inch label - centered on the page and scaled to fill exactly 4x6 inches (no margins)",
+                  description:
+                    "PNG 4x6 inch label - centered on the page and scaled to fill exactly 4x6 inches (no margins)",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=png_4_x_6"
                 },
                 pdf_4_x_6: %Schema{
                   type: :string,
-                  description: "PDF 4x6 inch label - centered and scaled to full size with 0.5 inch margins on all sides",
+                  description:
+                    "PDF 4x6 inch label - centered and scaled to full size with 0.5 inch margins on all sides",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_4_x_6"
                 },
                 pdf_letter: %Schema{
                   type: :string,
-                  description: "PDF US Letter (8.5x11 inch) - centered and scaled to full size with 1 inch margins on all sides",
+                  description:
+                    "PDF US Letter (8.5x11 inch) - centered and scaled to full size with 1 inch margins on all sides",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_letter"
                 },
                 pdf_letter_half_page: %Schema{
                   type: :string,
-                  description: "PDF US Letter landscape (11x8.5 inch) - 4x6 label on left half with 1.5 inch top/bottom and 1.25 inch left/right margins",
+                  description:
+                    "PDF US Letter landscape (11x8.5 inch) - 4x6 label on left half with 1.5 inch top/bottom and 1.25 inch left/right margins",
                   nullable: true,
-                  example: "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page"
+                  example:
+                    "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page"
                 },
                 pdf_a4: %Schema{
                   type: :string,
-                  description: "PDF A4 (8.3x11.7 inch) - centered and scaled to full size with 1 inch top/bottom and 1.25 inch left/right margins",
+                  description:
+                    "PDF A4 (8.3x11.7 inch) - centered and scaled to full size with 1 inch top/bottom and 1.25 inch left/right margins",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_a4"
                 },
                 pdf_a4_half_page: %Schema{
                   type: :string,
-                  description: "PDF A4 landscape (11.7x8.3 inch) - 4x6 label on left half with 1.15 inch top/bottom and 1.85 inch left/right margins",
+                  description:
+                    "PDF A4 landscape (11.7x8.3 inch) - 4x6 label on left half with 1.15 inch top/bottom and 1.85 inch left/right margins",
                   nullable: true,
-                  example: "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page"
+                  example:
+                    "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page"
                 },
                 zpl_8dpmm: %Schema{
                   type: :string,
-                  description: "ZPL for 8 dots/mm (203 DPI) printers - 4x6 label centered on the media at native resolution",
+                  description:
+                    "ZPL for 8 dots/mm (203 DPI) printers - 4x6 label centered on the media at native resolution",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=zpl_8dpmm"
                 },
                 zpl_12dpmm: %Schema{
                   type: :string,
-                  description: "ZPL for 12 dots/mm (300 DPI) printers - 4x6 label centered on the media at native resolution",
+                  description:
+                    "ZPL for 12 dots/mm (300 DPI) printers - 4x6 label centered on the media at native resolution",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=zpl_12dpmm"
                 }
@@ -276,10 +286,13 @@ defmodule DocsWeb.Schemas.Response.Shipment do
               example: %{
                 "png_4_x_6" => "https://labels.example.com/labels/456/token123?format=png_4_x_6",
                 "pdf_4_x_6" => "https://labels.example.com/labels/456/token123?format=pdf_4_x_6",
-                "pdf_letter" => "https://labels.example.com/labels/456/token123?format=pdf_letter",
-                "pdf_letter_half_page" => "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page",
+                "pdf_letter" =>
+                  "https://labels.example.com/labels/456/token123?format=pdf_letter",
+                "pdf_letter_half_page" =>
+                  "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page",
                 "pdf_a4" => "https://labels.example.com/labels/456/token123?format=pdf_a4",
-                "pdf_a4_half_page" => "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page",
+                "pdf_a4_half_page" =>
+                  "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page",
                 "zpl_8dpmm" => "https://labels.example.com/labels/456/token123?format=zpl_8dpmm",
                 "zpl_12dpmm" => "https://labels.example.com/labels/456/token123?format=zpl_12dpmm"
               }
@@ -379,6 +392,12 @@ defmodule DocsWeb.Schemas.Response.Shipment do
             %{
               "components" => [
                 %{
+                  "customs" => %{
+                    "country_of_origin" => "US",
+                    "hs_code" => "123456",
+                    "medium" => "oil on canvas",
+                    "temporary_admission" => true
+                  },
                   "details" => %{
                     "creation_date" => "1980",
                     "creator" => "Bob Smithson",


### PR DESCRIPTION
In this PR, I introduced the `components` blob under the `objects` data for the input/output data of 
- Hosted Sessions
- Requests
- Shipments

I've also added some samples for both regular and prepacked_box objects.

<img width="1773" alt="image" src="https://github.com/user-attachments/assets/78ee9cea-d035-4f8c-8bce-7dcdaf7ce0b5" />


This PR should be merged once the "Client Provided Boxes" project is live!