### PR TITLE
fix: add missing request object weight_unit property schema

### DIFF
--- a/lib/docs_web/schemas/response/request.ex
+++ b/lib/docs_web/schemas/response/request.ex
@@ -212,6 +212,10 @@ defmodule DocsWeb.Schemas.Response.Request do
               description: "The height of the object",
               type: "string"
             },
+            weight_unit: %Schema{
+              type: "string",
+              enum: ["lb", "kg"]
+            },
             unit_of_measurement: %Schema{
               type: "string",
               enum: ["in", "cm"]

--- a/lib/docs_web/schemas/response/request.ex
+++ b/lib/docs_web/schemas/response/request.ex
@@ -209,7 +209,7 @@ defmodule DocsWeb.Schemas.Response.Request do
               type: "string"
             },
             weight: %Schema{
-              description: "The height of the object",
+              description: "The weight of the object",
               type: "string"
             },
             weight_unit: %Schema{


### PR DESCRIPTION
My [OpenAPI-Generator generated Java SDK](https://github.com/invaluable/arta-client-java) was missing this field in the generated models, and I remembered @dylanfareed had shared this repo with me, so I figured I'd open a PR.

I have not tested this change