### PR TITLE
feat: Add label_format_urls field to Shipment API schema documentation

### DIFF
--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -223,17 +223,63 @@ defmodule DocsWeb.Schemas.Response.Shipment do
               description:
                 "A map of shipping label format types to their respective download URLs. Returns null if no shipping label exists",
               nullable: true,
-              additionalProperties: %Schema{
-                type: :string,
-                nullable: true
+              properties: %{
+                png_4_x_6: %Schema{
+                  type: :string,
+                  description: "PNG 4x6 inches - Centers the 4x6 label on the page, scales it up to full size",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=png_4_x_6"
+                },
+                pdf_4_x_6: %Schema{
+                  type: :string,
+                  description: "PDF 4x6 inches - Centers the 4x6 label on the page, scales it up to full size",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=pdf_4_x_6"
+                },
+                pdf_letter: %Schema{
+                  type: :string,
+                  description: "PDF US Letter (8.5x11 inches) - Centers the label on the page, scales it up to full size",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=pdf_letter"
+                },
+                pdf_letter_half_page: %Schema{
+                  type: :string,
+                  description: "PDF US Letter landscape, half page (8.5x11 inches) - 4x6 label positioned on left side",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page"
+                },
+                pdf_a4: %Schema{
+                  type: :string,
+                  description: "PDF A4 paper (8.3x11.7 inches) - Centers the label on the page, scales it up to full size",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=pdf_a4"
+                },
+                pdf_a4_half_page: %Schema{
+                  type: :string,
+                  description: "PDF A4 landscape, half page (8.3x11.7 inches) - 4x6 label positioned on left side",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page"
+                },
+                zpl_8dpmm: %Schema{
+                  type: :string,
+                  description: "ZPL for 8 dots/mm printers (203 DPI) - Centers the 4x6 label on the page, scales it up to full size",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=zpl_8dpmm"
+                },
+                zpl_12dpmm: %Schema{
+                  type: :string,
+                  description: "ZPL for 12 dots/mm printers (300 DPI) - Centers the 4x6 label on the page, scales it up to full size",
+                  nullable: true,
+                  example: "https://labels.example.com/labels/456/token123?format=zpl_12dpmm"
+                }
               },
               example: %{
+                "png_4_x_6" => "https://labels.example.com/labels/456/token123?format=png_4_x_6",
                 "pdf_4_x_6" => "https://labels.example.com/labels/456/token123?format=pdf_4_x_6",
-                "pdf_a4" => "https://labels.example.com/labels/456/token123?format=pdf_a4",
-                "pdf_a4_half_page" => "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page",
                 "pdf_letter" => "https://labels.example.com/labels/456/token123?format=pdf_letter",
                 "pdf_letter_half_page" => "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page",
-                "png_4_x_6" => "https://labels.example.com/labels/456/token123?format=png_4_x_6",
+                "pdf_a4" => "https://labels.example.com/labels/456/token123?format=pdf_a4",
+                "pdf_a4_half_page" => "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page",
                 "zpl_8dpmm" => "https://labels.example.com/labels/456/token123?format=zpl_8dpmm",
                 "zpl_12dpmm" => "https://labels.example.com/labels/456/token123?format=zpl_12dpmm"
               }

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -232,31 +232,31 @@ defmodule DocsWeb.Schemas.Response.Shipment do
                 },
                 pdf_4_x_6: %Schema{
                   type: :string,
-                  description: "PDF 4x6 inches - Centers the 4x6 label on the page, scales it up to full size",
+                  description: "PDF 4x6 inches - Centers the label on the page, scales it up to full size with 0.5\" margins on all four sides",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_4_x_6"
                 },
                 pdf_letter: %Schema{
                   type: :string,
-                  description: "PDF US Letter (8.5x11 inches) - Centers the label on the page, scales it up to full size",
+                  description: "PDF US Letter (8.5x11 inches) - Centers the label on the page, scales it up to full size with 1\" margins on all four sides",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_letter"
                 },
                 pdf_letter_half_page: %Schema{
                   type: :string,
-                  description: "PDF US Letter landscape, half page (8.5x11 inches) - 4x6 label positioned on left side",
+                  description: "PDF US Letter landscape, half page (8.5x11 inches) - 4x6 label positioned on left side with 1.5\" top/bottom margins and 1.25\" left/right margins",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page"
                 },
                 pdf_a4: %Schema{
                   type: :string,
-                  description: "PDF A4 paper (8.3x11.7 inches) - Centers the label on the page, scales it up to full size",
+                  description: "PDF A4 paper (8.3x11.7 inches) - Centers the label on the page, scales it up to full size with 1\" top/bottom margins and 1.25\" left/right margins",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_a4"
                 },
                 pdf_a4_half_page: %Schema{
                   type: :string,
-                  description: "PDF A4 landscape, half page (8.3x11.7 inches) - 4x6 label positioned on left side",
+                  description: "PDF A4 landscape, half page (8.3x11.7 inches) - 4x6 label positioned on left side with 1.15\" top/bottom margins and 1.85\" left/right margins",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page"
                 },

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -215,7 +215,7 @@ defmodule DocsWeb.Schemas.Response.Shipment do
             label_url: %Schema{
               type: :string,
               description:
-                "A URL at which parcel package shipping labels may be downladed and printed",
+                "A URL at which parcel package shipping labels may be downloaded and printed",
               nullable: true
             },
             label_format_urls: %Schema{
@@ -226,49 +226,49 @@ defmodule DocsWeb.Schemas.Response.Shipment do
               properties: %{
                 png_4_x_6: %Schema{
                   type: :string,
-                  description: "PNG 4x6 inches - Centers the 4x6 label on the page, scales it up to full size",
+                  description: "PNG 4x6 inch label - centered on the page and scaled to fill exactly 4x6 inches (no margins)",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=png_4_x_6"
                 },
                 pdf_4_x_6: %Schema{
                   type: :string,
-                  description: "PDF 4x6 inches - Centers the label on the page, scales it up to full size with 0.5\" margins on all four sides",
+                  description: "PDF 4x6 inch label - centered and scaled to full size with 0.5 inch margins on all sides",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_4_x_6"
                 },
                 pdf_letter: %Schema{
                   type: :string,
-                  description: "PDF US Letter (8.5x11 inches) - Centers the label on the page, scales it up to full size with 1\" margins on all four sides",
+                  description: "PDF US Letter (8.5x11 inch) - centered and scaled to full size with 1 inch margins on all sides",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_letter"
                 },
                 pdf_letter_half_page: %Schema{
                   type: :string,
-                  description: "PDF US Letter landscape, half page (8.5x11 inches) - 4x6 label positioned on left side with 1.5\" top/bottom margins and 1.25\" left/right margins",
+                  description: "PDF US Letter landscape (11x8.5 inch) - 4x6 label on left half with 1.5 inch top/bottom and 1.25 inch left/right margins",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page"
                 },
                 pdf_a4: %Schema{
                   type: :string,
-                  description: "PDF A4 paper (8.3x11.7 inches) - Centers the label on the page, scales it up to full size with 1\" top/bottom margins and 1.25\" left/right margins",
+                  description: "PDF A4 (8.3x11.7 inch) - centered and scaled to full size with 1 inch top/bottom and 1.25 inch left/right margins",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_a4"
                 },
                 pdf_a4_half_page: %Schema{
                   type: :string,
-                  description: "PDF A4 landscape, half page (8.3x11.7 inches) - 4x6 label positioned on left side with 1.15\" top/bottom margins and 1.85\" left/right margins",
+                  description: "PDF A4 landscape (11.7x8.3 inch) - 4x6 label on left half with 1.15 inch top/bottom and 1.85 inch left/right margins",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page"
                 },
                 zpl_8dpmm: %Schema{
                   type: :string,
-                  description: "ZPL for 8 dots/mm printers (203 DPI) - Centers the 4x6 label on the page, scales it up to full size",
+                  description: "ZPL for 8 dots/mm (203 DPI) printers - 4x6 label centered on the media at native resolution",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=zpl_8dpmm"
                 },
                 zpl_12dpmm: %Schema{
                   type: :string,
-                  description: "ZPL for 12 dots/mm printers (300 DPI) - Centers the 4x6 label on the page, scales it up to full size",
+                  description: "ZPL for 12 dots/mm (300 DPI) printers - 4x6 label centered on the media at native resolution",
                   nullable: true,
                   example: "https://labels.example.com/labels/456/token123?format=zpl_12dpmm"
                 }

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -218,6 +218,26 @@ defmodule DocsWeb.Schemas.Response.Shipment do
                 "A URL at which parcel package shipping labels may be downladed and printed",
               nullable: true
             },
+            label_format_urls: %Schema{
+              type: :object,
+              description:
+                "A map of shipping label format types to their respective download URLs. Returns null if no shipping label exists",
+              nullable: true,
+              additionalProperties: %Schema{
+                type: :string,
+                nullable: true
+              },
+              example: %{
+                "pdf_4_x_6" => "https://labels.example.com/labels/456/token123?format=pdf_4_x_6",
+                "pdf_a4" => "https://labels.example.com/labels/456/token123?format=pdf_a4",
+                "pdf_a4_half_page" => "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page",
+                "pdf_letter" => "https://labels.example.com/labels/456/token123?format=pdf_letter",
+                "pdf_letter_half_page" => "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page",
+                "png_4_x_6" => "https://labels.example.com/labels/456/token123?format=png_4_x_6",
+                "zpl_8dpmm" => "https://labels.example.com/labels/456/token123?format=zpl_8dpmm",
+                "zpl_12dpmm" => "https://labels.example.com/labels/456/token123?format=zpl_12dpmm"
+              }
+            },
             package_id: %Schema{
               type: :integer,
               format: :int64,


### PR DESCRIPTION
Updates the OpenAPI schema for the Shipment response to include the new `label_format_urls` field in package tracking data with comprehensive format specifications and detailed descriptions.

## Changes Made

- **Added `label_format_urls` field** to tracking items properties in `DocsWeb.Schemas.Response.Shipment`
- **Complete format specification** with individual properties for each supported label format
- **Detailed descriptions** including positioning and scaling behavior for each format
- **Comprehensive examples** showing URL structure for all formats

## Schema Definition

The new field provides a map of shipping label format types to their download URLs with detailed specifications:

### Supported Formats:
- **PNG 4x6**: `png_4_x_6` - Centers the 4x6 label on the page, scales it up to full size
- **PDF 4x6**: `pdf_4_x_6` - Centers the label on the page, scales it up to full size with 0.5" margins on all four sides
- **PDF Letter**: `pdf_letter` - US Letter (8.5x11 inches), centers the label on the page, scales it up to full size with 1" margins on all four sides
- **PDF Letter Half**: `pdf_letter_half_page` - US Letter landscape, 4x6 label positioned on left side with 1.5" top/bottom margins and 1.25" left/right margins
- **PDF A4**: `pdf_a4` - A4 paper (8.3x11.7 inches), centers the label on the page, scales it up to full size with 1" top/bottom margins and 1.25" left/right margins
- **PDF A4 Half**: `pdf_a4_half_page` - A4 landscape, 4x6 label positioned on left side with 1.15" top/bottom margins and 1.85" left/right margins
- **ZPL 203 DPI**: `zpl_8dpmm` - For 8 dots/mm printers (203 DPI), centers the 4x6 label on the page
- **ZPL 300 DPI**: `zpl_12dpmm` - For 12 dots/mm printers (300 DPI), centers the 4x6 label on the page


### Example Response:
```json
"label_format_urls": {
  "png_4_x_6": "https://labels.example.com/labels/456/token123?format=png_4_x_6",
  "pdf_4_x_6": "https://labels.example.com/labels/456/token123?format=pdf_4_x_6",
  "pdf_letter": "https://labels.example.com/labels/456/token123?format=pdf_letter",
  "pdf_letter_half_page": "https://labels.example.com/labels/456/token123?format=pdf_letter_half_page",
  "pdf_a4": "https://labels.example.com/labels/456/token123?format=pdf_a4",
  "pdf_a4_half_page": "https://labels.example.com/labels/456/token123?format=pdf_a4_half_page",
  "zpl_8dpmm": "https://labels.example.com/labels/456/token123?format=zpl_8dpmm",
  "zpl_12dpmm": "https://labels.example.com/labels/456/token123?format=zpl_12dpmm"
}
```