### PR TITLE
Fix date format for OpenAPI v3 compability

### DIFF
--- a/lib/docs_web/schemas/fields.ex
+++ b/lib/docs_web/schemas/fields.ex
@@ -486,7 +486,6 @@ defmodule DocsWeb.Schemas.Fields do
       hold_until: %Schema{
         type: :string,
         description: "The date the shipment will be held until",
-        format: "date",
         nullable: true
       },
       id: %Schema{

--- a/lib/docs_web/schemas/response/shipment.ex
+++ b/lib/docs_web/schemas/response/shipment.ex
@@ -137,12 +137,10 @@ defmodule DocsWeb.Schemas.Response.Shipment do
         properties: %{
           delivery_end: %Schema{
             type: :string,
-            format: :date,
             nullable: true
           },
           delivery_start: %Schema{
             type: :string,
-            format: :date,
             nullable: true
           },
           delivery_window_modifier: %Schema{
@@ -153,12 +151,10 @@ defmodule DocsWeb.Schemas.Response.Shipment do
           },
           pickup_end: %Schema{
             type: :string,
-            format: :date,
             nullable: true
           },
           pickup_start: %Schema{
             type: :string,
-            format: :date,
             nullable: true
           },
           pickup_window_modifier: %Schema{


### PR DESCRIPTION
OpenAPI v3 spec only supports date following RFC3339 full date which are not the ones returned by the API For the time, this makes the field essentially any string for clients to parse (with known constraint that the API uses MM/DD/YYYY

See: https://spec.openapis.org/oas/v3.0.0#data-types