### PR TITLE
feat: add insurance policy metadata endpoints documentation

### DIFF
--- a/lib/docs_web/api_spec.ex
+++ b/lib/docs_web/api_spec.ex
@@ -856,6 +856,67 @@ Use the private url in the successful hosted session response to direct your use
             }
           }
         },
+        "/metadata/insurance_policy_statuses" => %PathItem{
+          get: %Operation{
+            summary: "Insurance Policy Statuses",
+            description: "The list of insurance policy statuses supported by Arta's API.",
+            tags: [
+              "metadata"
+            ],
+            operationId: "metadata/insurancePolicyStatuses",
+            parameters: [Authorization.parameter()],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "A collection of insurance policy statuses",
+                  "application/json",
+                  Response.Metadata.InsurancePolicyStatus,
+                  headers: default_headers()
+                )
+            }
+          }
+        },
+        "/metadata/insurance_policy_coverage_types" => %PathItem{
+          get: %Operation{
+            summary: "Insurance Policy Coverage Types",
+            description: "The list of insurance policy coverage types supported by Arta's API.",
+            tags: [
+              "metadata"
+            ],
+            operationId: "metadata/insurancePolicyCoverageTypes",
+            parameters: [Authorization.parameter()],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "A collection of insurance policy coverage types",
+                  "application/json",
+                  Response.Metadata.InsurancePolicyCoverageType,
+                  headers: default_headers()
+                )
+            }
+          }
+        },
+        "/metadata/insurance_policy_booking_disqualifications" => %PathItem{
+          get: %Operation{
+            summary: "Insurance Policy Booking Disqualifications",
+            description:
+              "The list of reasons that may disqualify an insurance policy from being booked.",
+            tags: [
+              "metadata"
+            ],
+            operationId: "metadata/insurancePolicyBookingDisqualifications",
+            parameters: [Authorization.parameter()],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "A collection of insurance policy booking disqualifications",
+                  "application/json",
+                  Response.Metadata.InsurancePolicyBookingDisqualification,
+                  headers: default_headers()
+                )
+            }
+          }
+        },
         "/metadata/location_access_restrictions" => %PathItem{
           get: %Operation{
             summary: "Location Access Restrictions",

--- a/lib/docs_web/schemas/response/metadata/insurance_policy_booking_disqualification.ex
+++ b/lib/docs_web/schemas/response/metadata/insurance_policy_booking_disqualification.ex
@@ -13,7 +13,7 @@ defmodule DocsWeb.Schemas.Response.Metadata.InsurancePolicyBookingDisqualificati
           type: :string,
           description: "A long form description",
           example:
-            "Insurance coverage cannot be activated because the package is already in transit."
+            "Insurance coverage cannot be activated because one or more packages have already been picked up by the carrier. Coverage must be purchased before shipment begins."
         },
         id: %Schema{
           type: :string,

--- a/lib/docs_web/schemas/response/metadata/insurance_policy_booking_disqualification.ex
+++ b/lib/docs_web/schemas/response/metadata/insurance_policy_booking_disqualification.ex
@@ -1,0 +1,31 @@
+defmodule DocsWeb.Schemas.Response.Metadata.InsurancePolicyBookingDisqualification do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "MetadataInsurancePolicyBookingDisqualification",
+    type: :array,
+    items: %Schema{
+      type: :object,
+      properties: %{
+        description: %Schema{
+          type: :string,
+          description: "A long form description",
+          example:
+            "Insurance coverage cannot be activated because the package is already in transit."
+        },
+        id: %Schema{
+          type: :string,
+          description: "The ID representing the resource",
+          example: "package_in_transit"
+        },
+        name: %Schema{
+          type: :string,
+          description: "A brief title for the resource",
+          example: "Package in transit"
+        }
+      }
+    }
+  })
+end

--- a/lib/docs_web/schemas/response/metadata/insurance_policy_coverage_type.ex
+++ b/lib/docs_web/schemas/response/metadata/insurance_policy_coverage_type.ex
@@ -12,7 +12,7 @@ defmodule DocsWeb.Schemas.Response.Metadata.InsurancePolicyCoverageType do
         description: %Schema{
           type: :string,
           description: "A long form description",
-          example: "Coverage for shipments handled through Arta's shipping services."
+          example: "Coverage for shipments handled through Arta's shipping services"
         },
         id: %Schema{
           type: :string,

--- a/lib/docs_web/schemas/response/metadata/insurance_policy_coverage_type.ex
+++ b/lib/docs_web/schemas/response/metadata/insurance_policy_coverage_type.ex
@@ -1,0 +1,30 @@
+defmodule DocsWeb.Schemas.Response.Metadata.InsurancePolicyCoverageType do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "MetadataInsurancePolicyCoverageType",
+    type: :array,
+    items: %Schema{
+      type: :object,
+      properties: %{
+        description: %Schema{
+          type: :string,
+          description: "A long form description",
+          example: "Coverage for shipments handled through Arta's shipping services."
+        },
+        id: %Schema{
+          type: :string,
+          description: "The ID representing the resource",
+          example: "arta_shipping"
+        },
+        name: %Schema{
+          type: :string,
+          description: "A brief title for the resource",
+          example: "Arta Shipping"
+        }
+      }
+    }
+  })
+end

--- a/lib/docs_web/schemas/response/metadata/insurance_policy_status.ex
+++ b/lib/docs_web/schemas/response/metadata/insurance_policy_status.ex
@@ -1,0 +1,30 @@
+defmodule DocsWeb.Schemas.Response.Metadata.InsurancePolicyStatus do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "MetadataInsurancePolicyStatus",
+    type: :array,
+    items: %Schema{
+      type: :object,
+      properties: %{
+        description: %Schema{
+          type: :string,
+          description: "A long form description",
+          example: "The insurance policy is currently active and providing coverage."
+        },
+        id: %Schema{
+          type: :string,
+          description: "The ID representing the resource",
+          example: "active"
+        },
+        name: %Schema{
+          type: :string,
+          description: "A brief title for the resource",
+          example: "Active"
+        }
+      }
+    }
+  })
+end

--- a/lib/docs_web/schemas/response/metadata/insurance_policy_status.ex
+++ b/lib/docs_web/schemas/response/metadata/insurance_policy_status.ex
@@ -12,7 +12,7 @@ defmodule DocsWeb.Schemas.Response.Metadata.InsurancePolicyStatus do
         description: %Schema{
           type: :string,
           description: "A long form description",
-          example: "The insurance policy is currently active and providing coverage."
+          example: "in transit state"
         },
         id: %Schema{
           type: :string,

--- a/lib/docs_web/schemas/response/nullable_location.ex
+++ b/lib/docs_web/schemas/response/nullable_location.ex
@@ -32,7 +32,8 @@ defmodule DocsWeb.Schemas.Response.NullableLocation do
       },
       region: %Schema{
         type: :string,
-        description: "Political region name, for US states and Canada provinces, use 2 letter abbreviations"
+        description:
+          "Political region name, for US states and Canada provinces, use 2 letter abbreviations"
       },
       postal_code: %Schema{
         type: :string,
@@ -42,7 +43,8 @@ defmodule DocsWeb.Schemas.Response.NullableLocation do
         type: :string,
         maxLength: 2,
         minLength: 2,
-        description: "The ISO 3166-1 alpha-2 country code of the current or last known location if available"
+        description:
+          "The ISO 3166-1 alpha-2 country code of the current or last known location if available"
       },
       title: %Schema{
         type: :string,


### PR DESCRIPTION
## Summary
- Add API documentation for insurance policy metadata endpoints
- Documents three new metadata endpoint categories for insurance policies

## New Endpoints Documented

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/metadata/insurance_policy_statuses` | List all insurance policy statuses |
| GET | `/metadata/insurance_policy_coverage_types` | List all insurance policy coverage types |
| GET | `/metadata/insurance_policy_booking_disqualifications` | List all booking disqualification reasons |

## Files Changed

### New Files
| File | Description |
|------|-------------|
| `lib/docs_web/schemas/response/metadata/insurance_policy_status.ex` | Schema for insurance policy status response |
| `lib/docs_web/schemas/response/metadata/insurance_policy_coverage_type.ex` | Schema for insurance policy coverage type response |
| `lib/docs_web/schemas/response/metadata/insurance_policy_booking_disqualification.ex` | Schema for booking disqualification response |

### Modified Files
| File | Change |
|------|--------|
| `lib/docs_web/api_spec.ex` | Added 3 new metadata endpoint definitions |

## Response Format

All three endpoints return arrays with the same structure:

```json
[
  {
    "id": "example_id",
    "name": "Example Name",
    "description": "A detailed description of the resource."
  }
]
```
