### PR TITLE
feat: add TestModeTransformation API documentation

### DIFF
--- a/lib/docs_web/api_spec.ex
+++ b/lib/docs_web/api_spec.ex
@@ -29,14 +29,15 @@ defmodule DocsWeb.ApiSpec do
   alias DocsWeb.Parameters.{Authorization, Page, PageSize}
 
   alias DocsWeb.Schemas.RequestBody.{
+    ApiKeyCreate,
     AttachmentCreate,
     CollectionTagRuleCreate,
     HostedSessionCreate,
-    ApiKeyCreate,
     OrganizationUpdate,
     ShipmentCreate,
     TagCreate,
-    TagUpdate
+    TagUpdate,
+    TestModeTransformationCreate
   }
 
   @behaviour OpenApi
@@ -2323,6 +2324,145 @@ Use the private url in the successful hosted session response to direct your use
                   "Successful Webhook response",
                   "application/json",
                   Response.WebhookSecretToken,
+                  headers: default_headers()
+                ),
+              404 => Response.NotFound.build()
+            }
+          }
+        },
+        "/test_mode_transformations/options" => %PathItem{
+          get: %Operation{
+            summary: "List Test Mode Transformation Options",
+            description: """
+              Retrieve the list of available test mode transformation types for a specific resource. Test mode transformations allow you to
+              simulate state changes in shipments and requests during testing.
+
+              This endpoint returns the transformations that are valid for the specified resource based on its current state.
+
+              Available test mode transformation types:
+              * `confirm` - Confirms a shipment, advancing it from pending to confirmed state
+              * `collect` - Marks a shipment as collected from the origin location
+              * `transit` - Updates a shipment to in-transit status
+              * `complete` - Marks a shipment as completed/delivered
+              * `cancel` - Cancels a shipment or request
+              * `expire` - Expires a request that is no longer needed
+            """,
+            tags: ["test_mode_transformations"],
+            operationId: "testModeTransformations/options",
+            parameters: [
+              Authorization.parameter(),
+              Parameters.TestModeTransformationResourceID.parameter(),
+              Parameters.TestModeTransformationResourceType.parameter()
+            ],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "A collection of available test mode transformation types",
+                  "application/json",
+                  Response.Metadata.TestModeTransformationType,
+                  headers: default_headers()
+                )
+            }
+          }
+        },
+        "/test_mode_transformations" => %PathItem{
+          get: %Operation{
+            summary: "List Test Mode Transformations",
+            description: """
+              Retrieve a paginated collection of test mode transformation resources. This endpoint allows you to view
+              the history of Test Mode Transformations for your organization and filter by resource_id and/or resource_type.
+            """,
+            tags: ["test_mode_transformations"],
+            operationId: "testModeTransformations/list",
+            parameters: [
+              Authorization.parameter(),
+              Parameters.TestModeTransformationResourceID.parameter(),
+              Parameters.TestModeTransformationResourceType.parameter(),
+              Page.parameter(),
+              PageSize.parameter()
+            ],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "A paginated collection of test mode transformations",
+                  "application/json",
+                  list(Response.TestModeTransformation),
+                  headers: default_headers()
+                )
+            }
+          },
+          post: %Operation{
+            summary: "Create a Test Mode Transformation",
+            description: """
+              Create a new test mode transformation resource to change the state of a shipment or request. This
+              endpoint simulates lifecycle events that would normally occur through the fulfillment process.
+
+              **Important Notes:**
+              * Test mode transformations only work in Test mode (using a test API key)
+              * The target resource (shipment or request) must exist and be in a compatible state
+              * Some transformation types may only apply to specific resource types
+              * Invalid state transitions will return a 422 error
+
+              **Common Use Cases:**
+              * Testing shipment lifecycle workflows
+              * Simulating delivery for integration testing
+              * Testing request expiration scenarios
+              * Validating webhook notifications for different states
+            """,
+            tags: ["test_mode_transformations"],
+            operationId: "testModeTransformations/create",
+            parameters: [Authorization.parameter()],
+            requestBody: %RequestBody{
+              content: %{
+                "application/json" => %MediaType{
+                  schema: TestModeTransformationCreate
+                }
+              }
+            },
+            responses: %{
+              201 =>
+                Operation.response(
+                  "The created test mode transformation",
+                  "application/json",
+                  Response.TestModeTransformation,
+                  headers: default_headers()
+                ),
+              400 => Response.BadRequest.build(),
+              403 =>
+                Operation.response(
+                  "Forbidden - test mode transformations are only available in test mode",
+                  "application/json",
+                  Response.Error
+                ),
+              404 => Response.NotFound.build(),
+              422 =>
+                Operation.response(
+                  "Unprocessable entity - invalid test mode transformation for current resource state",
+                  "application/json",
+                  Response.Error
+                )
+            }
+          }
+        },
+        "/test_mode_transformations/{test_mode_transformation_id}" => %PathItem{
+          get: %Operation{
+            summary: "Retrieve a Test Mode Transformation",
+            description: """
+              Retrieve an existing test mode transformation resource by its ID. This allows you to check the
+              status and details of a previously applied test mode transformation.
+            """,
+            tags: ["test_mode_transformations"],
+            operationId: "testModeTransformations/get",
+            parameters: [
+              Authorization.parameter(),
+              Parameters.TestModeTransformationID.parameter()
+            ],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "Successful test mode transformation get response",
+                  "application/json",
+                  Response.TestModeTransformation,
                   headers: default_headers()
                 ),
               404 => Response.NotFound.build()

--- a/lib/docs_web/parameters/test_mode_transformation_id.ex
+++ b/lib/docs_web/parameters/test_mode_transformation_id.ex
@@ -1,0 +1,16 @@
+defmodule DocsWeb.Parameters.TestModeTransformationID do
+  alias OpenApiSpex.{Parameter, Schema}
+  require OpenApiSpex
+
+  @spec parameter() :: Parameter.t()
+  def parameter(),
+    do: %Parameter{
+      name: "test_mode_transformation_id",
+      description: "test_mode_transformation_id parameter",
+      in: :path,
+      required: true,
+      schema: %Schema{
+        type: "string"
+      }
+    }
+end

--- a/lib/docs_web/parameters/test_mode_transformation_resource_id.ex
+++ b/lib/docs_web/parameters/test_mode_transformation_resource_id.ex
@@ -1,0 +1,18 @@
+defmodule DocsWeb.Parameters.TestModeTransformationResourceID do
+  alias OpenApiSpex.{Parameter, Schema}
+  require OpenApiSpex
+
+  @spec parameter() :: Parameter.t()
+  def parameter(),
+    do: %Parameter{
+      name: "id",
+      description:
+        "The ID of the resource (shipment or request) to get transformation options for",
+      in: :query,
+      required: true,
+      example: "506d79b6-1e5e-4e8c-a266-74658fdaf4ee",
+      schema: %Schema{
+        type: "string"
+      }
+    }
+end

--- a/lib/docs_web/parameters/test_mode_transformation_resource_type.ex
+++ b/lib/docs_web/parameters/test_mode_transformation_resource_type.ex
@@ -1,0 +1,18 @@
+defmodule DocsWeb.Parameters.TestModeTransformationResourceType do
+  alias OpenApiSpex.{Parameter, Schema}
+  require OpenApiSpex
+
+  @spec parameter() :: Parameter.t()
+  def parameter(),
+    do: %Parameter{
+      name: "type",
+      description: "The type of resource to get transformation options for",
+      in: :query,
+      required: true,
+      example: "shipment",
+      schema: %Schema{
+        type: "string",
+        enum: ["shipment", "request"]
+      }
+    }
+end

--- a/lib/docs_web/schemas/request_body/test_mode_transformation_create.ex
+++ b/lib/docs_web/schemas/request_body/test_mode_transformation_create.ex
@@ -1,0 +1,47 @@
+defmodule DocsWeb.Schemas.RequestBody.TestModeTransformationCreate do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%Schema{
+    title: "TestModeTransformationCreate",
+    type: :object,
+    properties: %{
+      test_mode_transformation: %Schema{
+        type: :object,
+        properties: %{
+          type: %Schema{
+            description: """
+              The type of transformation to apply. Available types include:
+
+              * `confirm` - Confirms a shipment, advancing it from pending to confirmed state
+              * `collect` - Marks a shipment as collected from the origin location
+              * `transit` - Updates a shipment to in-transit status
+              * `complete` - Marks a shipment as completed/delivered
+              * `cancel` - Cancels a shipment or request
+              * `expire` - Expires a request that is no longer needed
+            """,
+            type: :string,
+            enum: ["confirm", "collect", "transit", "complete", "cancel", "expire"],
+            example: "confirm"
+          },
+          resource_type: %Schema{
+            description:
+              "The type of resource to transform. Must be either `shipment` or `request`",
+            type: :string,
+            enum: ["shipment", "request"],
+            example: "shipment"
+          },
+          resource_id: %Schema{
+            description: "The ID of the shipment or request to transform",
+            type: :string,
+            example: "506d79b6-1e5e-4e8c-a266-74658fdaf4ee"
+          }
+        },
+        required: ["type", "resource_type", "resource_id"]
+      }
+    },
+    required: ["test_mode_transformation"],
+    additionalProperties: false
+  })
+end

--- a/lib/docs_web/schemas/response/metadata/test_mode_transformation_type.ex
+++ b/lib/docs_web/schemas/response/metadata/test_mode_transformation_type.ex
@@ -1,0 +1,30 @@
+defmodule DocsWeb.Schemas.Response.Metadata.TestModeTransformationType do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "MetadataTestModeTransformationType",
+    type: :array,
+    items: %Schema{
+      type: :object,
+      properties: %{
+        description: %Schema{
+          type: :string,
+          description: "A description of what this transformation type does",
+          example: "Confirms a shipment"
+        },
+        id: %Schema{
+          type: :string,
+          description: "The ID representing the transformation type",
+          example: "confirm"
+        },
+        name: %Schema{
+          type: :string,
+          description: "A brief title for the transformation type",
+          example: "Confirm"
+        }
+      }
+    }
+  })
+end

--- a/lib/docs_web/schemas/response/test_mode_transformation.ex
+++ b/lib/docs_web/schemas/response/test_mode_transformation.ex
@@ -1,0 +1,53 @@
+defmodule DocsWeb.Schemas.Response.TestModeTransformation do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  OpenApiSpex.schema(%{
+    title: "TestModeTransformation",
+    type: :object,
+    properties: %{
+      id: %Schema{
+        type: "string",
+        description: "The unique identifier for the test mode transformation",
+        example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      },
+      type: %Schema{
+        type: "string",
+        description:
+          "The type of transformation to apply. Available types include: confirm, collect, transit, complete, cancel, expire",
+        enum: ["confirm", "collect", "transit", "complete", "cancel", "expire"],
+        example: "confirm"
+      },
+      resource_type: %Schema{
+        type: "string",
+        description: "The type of resource being transformed (e.g., shipment or request)",
+        enum: ["shipment", "request"],
+        example: "shipment"
+      },
+      resource_id: %Schema{
+        type: "string",
+        description: "The ID of the resource (shipment or request) being transformed",
+        example: "506d79b6-1e5e-4e8c-a266-74658fdaf4ee"
+      },
+      created_at: %Schema{
+        type: "string",
+        description:
+          "A NaiveDatetime-formatted timestamp describing when the test mode transformation was created with microsecond precision",
+        example: "2021-01-21T21:00:58.403150"
+      },
+      status: %Schema{
+        type: "string",
+        description: "The current status of the test mode transformation",
+        enum: ["pending", "completed", "failed"],
+        example: "completed"
+      },
+      error_message: %Schema{
+        type: "string",
+        description: "Error message if the test mode transformation failed",
+        nullable: true,
+        example: nil
+      }
+    }
+  })
+end


### PR DESCRIPTION
Add comprehensive OpenAPI documentation for the test mode transformation API, which allows simulating state changes in shipments and requests during testing.

**Endpoints Added:**
- GET /test_mode_transformations/options - List available transformation types for a resource
- POST /test_mode_transformations - Create a new test mode transformation
- GET /test_mode_transformations - List transformations for a resource (paginated)
- GET /test_mode_transformations/:test_mode_transformation_id - Get specific transformation

**Features:**
- Full request/response schema definitions for TestModeTransformation resource
- Query parameters for filtering by resource ID and type (shipment/request)
- Documented transformation types: confirm, collect, transit, complete, cancel, expire
- Error responses for 400, 403, 404, and 422 status codes
- Pagination support for list endpoint
- Authentication via API key (test mode only)