### PR TITLE
feat: add DHL support and cancel endpoint to self-ship collections

### DIFF
--- a/lib/docs_web/api_spec.ex
+++ b/lib/docs_web/api_spec.ex
@@ -1638,11 +1638,55 @@ Use the private url in the successful hosted session response to direct your use
             }
           }
         },
+        "/self_ship_collections/{self_ship_collection_id}/cancel" => %PathItem{
+          patch: %Operation{
+            summary: "Cancel a Self-Ship Collection",
+            description:
+              "**Availability: Public Preview**\n\n_This endpoint is currently in public preview and available only to approved accounts._ _Please contact Arta to request access for your organization._\n\nCancel an existing self-ship collection. Cancellation is only supported for DHL collections; attempting to cancel a FedEx collection returns a `422` response with `{\"errors\": [\"Only DHL collections can be cancelled\"]}`.",
+            tags: ["self_ship_collections"],
+            operationId: "selfShipCollections/cancel",
+            parameters: [Authorization.parameter(), Parameters.SelfShipCollectionID.parameter()],
+            responses: %{
+              200 =>
+                Operation.response(
+                  "The cancelled self-ship collection",
+                  "application/json",
+                  Response.SelfShipCollection,
+                  headers: default_headers()
+                ),
+              403 =>
+                Operation.response(
+                  "Forbidden",
+                  "application/json",
+                  nil
+                ),
+              404 => Response.NotFound.build(),
+              422 =>
+                Operation.response(
+                  "The collection cannot be cancelled. Only DHL collections can be cancelled via the API.",
+                  "application/json",
+                  %Schema{
+                    title: "SelfShipCollectionCancelError",
+                    type: :object,
+                    properties: %{
+                      errors: %Schema{
+                        type: :array,
+                        description: "A list of human-readable error messages",
+                        items: %Schema{type: :string},
+                        example: ["Only DHL collections can be cancelled"]
+                      }
+                    }
+                  },
+                  headers: default_headers()
+                )
+            }
+          }
+        },
         "/self_ship_collection_availability_checks" => %PathItem{
           post: %Operation{
             summary: "Check Self-Ship Collection Availability",
             description:
-              "**Availability: Public Preview**\n\n_This endpoint is currently in public preview and available only to approved accounts._ _Please contact Arta to request access for your organization._\n\nCheck carrier pickup availability for a given location, service, and date",
+              "**Availability: Public Preview**\n\n_This endpoint is currently in public preview and available only to approved accounts._ _Please contact Arta to request access for your organization._\n\nCheck carrier pickup availability for a given location, service, and date.\n\nFor DHL, self-ship collections are supported in the US and UK. DHL pickups can be scheduled up to 10 days in advance, on business days only (Monday–Friday in the US, Monday–Saturday in the UK); the returned `availabilities` reflect these rules.",
             tags: ["self_ship_collections"],
             operationId: "selfShipCollectionAvailabilityChecks/create",
             parameters: [Authorization.parameter()],

--- a/lib/docs_web/api_spec.ex
+++ b/lib/docs_web/api_spec.ex
@@ -1668,6 +1668,7 @@ Use the private url in the successful hosted session response to direct your use
                   %Schema{
                     title: "SelfShipCollectionCancelError",
                     type: :object,
+                    required: [:errors],
                     properties: %{
                       errors: %Schema{
                         type: :array,

--- a/lib/docs_web/schemas/request_body/self_ship_collection_availability_check_create.ex
+++ b/lib/docs_web/schemas/request_body/self_ship_collection_availability_check_create.ex
@@ -66,8 +66,8 @@ defmodule DocsWeb.Schemas.RequestBody.SelfShipCollectionAvailabilityCheckCreate 
             properties: %{
               carrier: %Schema{
                 type: :string,
-                description: "Carrier identifier",
-                enum: ["fedex"]
+                description: "Carrier identifier. `fedex` and `dhl` are supported.",
+                enum: ["fedex", "dhl"]
               },
               code: %Schema{
                 type: :string,

--- a/lib/docs_web/schemas/request_body/self_ship_collection_create.ex
+++ b/lib/docs_web/schemas/request_body/self_ship_collection_create.ex
@@ -21,7 +21,6 @@ defmodule DocsWeb.Schemas.RequestBody.SelfShipCollectionCreate do
               "region",
               "postal_code",
               "close_time",
-              "package_location",
               "contact"
             ],
             properties: %{
@@ -66,7 +65,8 @@ defmodule DocsWeb.Schemas.RequestBody.SelfShipCollectionCreate do
               },
               package_location: %Schema{
                 type: :string,
-                description: "Where packages are located at the pickup location",
+                description:
+                  "Where packages are located at the pickup location. Optional. This is a FedEx-only dispatch hint and is ignored for DHL collections.",
                 enum: ["front", "none", "rear", "side"]
               },
               contact: %Schema{
@@ -101,8 +101,8 @@ defmodule DocsWeb.Schemas.RequestBody.SelfShipCollectionCreate do
             properties: %{
               carrier: %Schema{
                 type: :string,
-                description: "Carrier identifier",
-                enum: ["fedex"]
+                description: "Carrier identifier. `fedex` and `dhl` are supported.",
+                enum: ["fedex", "dhl"]
               },
               code: %Schema{
                 type: :string,
@@ -111,9 +111,97 @@ defmodule DocsWeb.Schemas.RequestBody.SelfShipCollectionCreate do
               },
               route: %Schema{
                 type: :string,
-                description: "Route type",
+                description:
+                  "Route type. For DHL collections this drives customs handling: `international` marks the pickup as customs-declarable, while `domestic` does not (the resulting `is_customs_declarable` value is derived server-side and is not a request field). Ignored for FedEx.",
                 enum: ["domestic", "international"],
                 nullable: true
+              },
+              package_details: %Schema{
+                title: "SelfShipCollectionPackageDetails",
+                description:
+                  "Package information for the collection. **Required for `dhl`** and provided as per-package dimensions and weight. **Optional for `fedex`** and provided as a package-count and total-weight summary; when omitted, existing FedEx behavior is unchanged.",
+                oneOf: [
+                  %Schema{
+                    title: "DhlPackageDetails",
+                    type: :object,
+                    description:
+                      "DHL package details. Provide one entry per package. All packages must share the same units, and the unit pair must be either `in` + `lb` or `cm` + `kg`.",
+                    required: ["packages"],
+                    properties: %{
+                      packages: %Schema{
+                        type: :array,
+                        description: "The packages included in the collection. Must contain at least one package.",
+                        minItems: 1,
+                        items: %Schema{
+                          type: :object,
+                          required: ["depth", "height", "width", "unit_of_measurement", "weight", "weight_unit"],
+                          properties: %{
+                            depth: %Schema{type: :number, description: "Package depth", example: 12},
+                            height: %Schema{type: :number, description: "Package height", example: 8},
+                            width: %Schema{type: :number, description: "Package width", example: 10},
+                            unit_of_measurement: %Schema{
+                              type: :string,
+                              description:
+                                "Unit for `depth`, `height`, and `width`. Must be `in` when `weight_unit` is `lb`, or `cm` when `weight_unit` is `kg`.",
+                              enum: ["in", "cm"],
+                              example: "in"
+                            },
+                            weight: %Schema{type: :number, description: "Package weight", example: 5},
+                            weight_unit: %Schema{
+                              type: :string,
+                              description:
+                                "Unit for `weight`. Must be `lb` when `unit_of_measurement` is `in`, or `kg` when it is `cm`.",
+                              enum: ["lb", "kg"],
+                              example: "lb"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    example: %{
+                      "packages" => [
+                        %{
+                          "depth" => 12,
+                          "height" => 8,
+                          "width" => 10,
+                          "unit_of_measurement" => "in",
+                          "weight" => 5,
+                          "weight_unit" => "lb"
+                        }
+                      ]
+                    }
+                  },
+                  %Schema{
+                    title: "FedexPackageDetails",
+                    type: :object,
+                    description:
+                      "FedEx package details: a summary of the total package count and weight for the pickup. Optional; when provided, the values are forwarded to FedEx as `packageCount` and `totalWeight`.",
+                    required: ["package_count", "total_weight", "total_weight_unit"],
+                    properties: %{
+                      package_count: %Schema{
+                        type: :integer,
+                        description: "Total number of packages in the pickup",
+                        example: 3
+                      },
+                      total_weight: %Schema{
+                        type: :number,
+                        description: "Combined weight of all packages",
+                        example: 15
+                      },
+                      total_weight_unit: %Schema{
+                        type: :string,
+                        description: "Unit for `total_weight`",
+                        enum: ["lb", "kg"],
+                        example: "lb"
+                      }
+                    },
+                    example: %{
+                      "package_count" => 3,
+                      "total_weight" => 15,
+                      "total_weight_unit" => "lb"
+                    }
+                  }
+                ]
               }
             }
           },

--- a/lib/docs_web/schemas/response/self_ship_collection.ex
+++ b/lib/docs_web/schemas/response/self_ship_collection.ex
@@ -122,7 +122,7 @@ defmodule DocsWeb.Schemas.Response.SelfShipCollection do
           carrier: %Schema{
             type: :string,
             description: "Carrier identifier",
-            enum: ["fedex"]
+            enum: ["fedex", "dhl"]
           },
           code: %Schema{
             type: :string,

--- a/lib/docs_web/schemas/response/self_ship_collection_availability_check.ex
+++ b/lib/docs_web/schemas/response/self_ship_collection_availability_check.ex
@@ -52,7 +52,7 @@ defmodule DocsWeb.Schemas.Response.SelfShipCollectionAvailabilityCheck do
           carrier: %Schema{
             type: :string,
             description: "Carrier identifier",
-            enum: ["fedex"]
+            enum: ["fedex", "dhl"]
           },
           code: %Schema{
             type: :string,


### PR DESCRIPTION
## Summary

Extends the self-ship collections API to support DHL alongside FedEx, and adds a cancel endpoint.

- Add `dhl` to the `carrier` enum on self-ship collection create, availability check, and their responses
- Add `package_details` to self-ship collection create as a `oneOf`:
  - **DHL** (required): per-package dimensions and weight; all packages share units (`in`+`lb` or `cm`+`kg`)
  - **FedEx** (optional): package-count + total-weight summary; when omitted, existing FedEx behavior is unchanged
- Make `package_location` optional and document it as a FedEx-only dispatch hint (ignored for DHL)
- Document that `route` drives DHL customs handling (`is_customs_declarable` derived server-side); ignored for FedEx
- Add `PATCH /self_ship_collections/{self_ship_collection_id}/cancel` — DHL-only; FedEx returns `422` with `{"errors": ["Only DHL collections can be cancelled"]}`
- Document DHL availability rules (US/UK, up to 10 days in advance, business days only)

## Verification

- `bin/lint-check` — format + credo pass, no issues
- `bin/run` — `openapi.json` generates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)